### PR TITLE
Potential fix for code scanning alert no. 10: Incorrect conversion between integer types

### DIFF
--- a/api/middleware/security_headers.go
+++ b/api/middleware/security_headers.go
@@ -14,7 +14,7 @@ func SecurityHeaders(contentSecurityPolicy string, next http.Handler) http.Handl
 	maxSize := DefaultMaxRequestSize
 
 	if maxSizeEnv := os.Getenv("MAX_REQUEST_SIZE"); maxSizeEnv != "" {
-		if size, err := strconv.ParseInt(maxSizeEnv, 10, 64); err == nil && size > 0 {
+		if size, err := strconv.ParseInt(maxSizeEnv, 10, strconv.IntSize); err == nil && size > 0 {
 			maxSize = int(size)
 		}
 	}


### PR DESCRIPTION
Potential fix for [https://github.com/henok321/knobel-manager-service/security/code-scanning/10](https://github.com/henok321/knobel-manager-service/security/code-scanning/10)

To fix the problem, we must ensure that the parsed `int64` value fits safely into the `int` type before casting. We should add an explicit upper and lower bound check against the size limits of `int` (using `math.MaxInt32`/`math.MinInt32` on 32-bit systems, or `math.MaxInt64`/`math.MinInt64` on 64-bit systems). Since `int` may have different sizes depending on the architecture, the safest portable solution is to use `strconv.ParseInt` with a bit size of `strconv.IntSize` (which gives the size of `int` on the current platform); alternatively, after parsing, check that the value lies between `math.MinInt` and `math.MaxInt`. However, Go does not provide `math.MaxInt` constants, only type-specific ones, but we can use `strconv.IntSize` for this.

**Best solution:** parse using `strconv.ParseInt(maxSizeEnv, 10, strconv.IntSize)` so that the parsed value is always representable as an `int` on the current platform. Then we can safely cast it, as Go will ensure it’s within the right bit width.

You only need to change the argument to `strconv.ParseInt` on line 17, from 64 to `strconv.IntSize`. No new imports are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
