### PR TITLE
Potential fix for code scanning alert no. 9: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -198,6 +198,7 @@ jobs:
     name: Deploy to Production
     needs: build
     runs-on: ubuntu-latest
+    permissions: {}
     environment:
       name: production
 


### PR DESCRIPTION
Potential fix for [https://github.com/henok321/knobel-manager-service/security/code-scanning/9](https://github.com/henok321/knobel-manager-service/security/code-scanning/9)

To fix this problem, add an explicit `permissions` block to the `deploy` job in `.github/workflows/pipeline.yml` to restrict GITHUB_TOKEN privileges to the minimum necessary. Since `deploy` does not require any GitHub API or token access (just secrets and environment variables for the external API), set `permissions: {}` (no permissions).  
Edit lines at the start of the `deploy` job (immediately under `runs-on` or above `environment`) and add the permissions block.  
No imports, methods, or other dependencies are needed, just the YAML block.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
