### PR TITLE
chore: migrate secret scanning from gitleaks to betterleaks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,10 +22,10 @@ repos:
       - id: detect-private-key
       - id: forbid-submodules
       - id: check-added-large-files
-  - repo: https://github.com/gitleaks/gitleaks
-    rev: v8.30.1
+  - repo: https://github.com/betterleaks/betterleaks
+    rev: v1.6.1
     hooks:
-      - id: gitleaks
+      - id: betterleaks
   - repo: https://github.com/EbodShojaei/bake
     rev: v1.4.6
     hooks:


### PR DESCRIPTION
## What

Swap the pre-commit secret-scanning hook from `gitleaks` to `betterleaks`.

```diff
-  - repo: https://github.com/gitleaks/gitleaks
-    rev: v8.30.1
-    hooks:
-      - id: gitleaks
+  - repo: https://github.com/betterleaks/betterleaks
+    rev: v1.6.1
+    hooks:
+      - id: betterleaks
```

## Why

Gitleaks is now in maintenance mode. Its own README states:

> Gitleaks is feature complete. I'm not merging new features into Gitleaks. Future releases will be security patches only. I'm shifting my focus to Betterleaks

Betterleaks is the same maintainer's (zricethezav / Zachary Rice) stated successor — MIT-licensed, backed by Aikido Security. No urgency (gitleaks still gets CVE patches), but new detection work lands on betterleaks, so it's the right project to track going forward.

## Notes

- Behaviorally equivalent: the hook runs `betterleaks git --pre-commit --redact --staged --verbose` — same staged-diff scan.
- `language: golang` (builds from source), same as the previous gitleaks hook — no new CI infrastructure.
- The `detect-private-key` hook is unchanged.

## Verification

`pre-commit run betterleaks --all-files` → **Passed** (clean scan). Full commit hook suite passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)