### PR TITLE
refactor: cut over-engineering flagged by audit

### DIFF
--- a/api/handlers/health_handler.go
+++ b/api/handlers/health_handler.go
@@ -24,7 +24,7 @@ var _ health.ServerInterface = (*HealthHandler)(nil)
 func (h *HealthHandler) LivenessCheck(writer http.ResponseWriter, request *http.Request) {
 	slog.DebugContext(request.Context(), "Handle liveness check")
 
-	response := health.HealthCheckResponse{Status: string(healthpkg.StatusPass)}
+	response := health.HealthCheckResponse{Status: "pass"}
 
 	writer.Header().Set("Content-Type", "application/json")
 	writer.WriteHeader(http.StatusOK)
@@ -36,38 +36,14 @@ func (h *HealthHandler) LivenessCheck(writer http.ResponseWriter, request *http.
 func (h *HealthHandler) ReadinessCheck(writer http.ResponseWriter, request *http.Request) {
 	slog.DebugContext(request.Context(), "Handle readiness check")
 
-	results := h.healthService.Readiness(request.Context())
-
-	checks := make(map[string]struct {
-		Message *string                                        `json:"message,omitempty"`
-		Status  health.HealthCheckDetailedResponseChecksStatus `json:"status"`
-	})
-	for name, result := range results.Checks {
-		checkValue := struct {
-			Message *string                                        `json:"message,omitempty"`
-			Status  health.HealthCheckDetailedResponseChecksStatus `json:"status"`
-		}{
-			Status: health.HealthCheckDetailedResponseChecksStatus(result.Status),
-		}
-		if result.Message != "" {
-			checkValue.Message = &result.Message
-		}
-		checks[name] = checkValue
-	}
-
-	response := health.HealthCheckDetailedResponse{
-		Status: health.HealthCheckDetailedResponseStatus(results.Status),
-	}
-	if len(checks) > 0 {
-		response.Checks = &checks
-	}
+	response := h.healthService.Readiness(request.Context())
 
 	statusCode := http.StatusOK
-	if results.Status != healthpkg.StatusPass {
+	if response.Status != health.HealthCheckDetailedResponseStatusPass {
 		statusCode = http.StatusServiceUnavailable
 		slog.WarnContext(request.Context(), "Readiness check failed",
-			"status", results.Status,
-			"checks", checks)
+			"status", response.Status,
+			"checks", response.Checks)
 	}
 
 	writer.Header().Set("Content-Type", "application/json")

--- a/api/health/checker.go
+++ b/api/health/checker.go
@@ -7,21 +7,3 @@ type Checker interface {
 
 	Check(ctx context.Context) error
 }
-
-type Status string
-
-const (
-	StatusPass Status = "pass"
-	StatusFail Status = "fail"
-)
-
-type CheckResult struct {
-	Name    string
-	Status  Status
-	Message string
-}
-
-type CheckResults struct {
-	Status Status
-	Checks map[string]CheckResult
-}

--- a/api/health/health.go
+++ b/api/health/health.go
@@ -3,7 +3,14 @@ package health
 import (
 	"context"
 	"sync/atomic"
+
+	"github.com/henok321/knobel-manager-service/gen/health"
 )
+
+type check = struct {
+	Message *string                                        `json:"message,omitempty"`
+	Status  health.HealthCheckDetailedResponseChecksStatus `json:"status"`
+}
 
 type Service struct {
 	checkers []Checker
@@ -16,35 +23,33 @@ func NewService(checkers ...Checker) *Service {
 	}
 }
 
-func (s *Service) Readiness(ctx context.Context) CheckResults {
+func (s *Service) Readiness(ctx context.Context) health.HealthCheckDetailedResponse {
 	if s.draining.Load() {
-		return CheckResults{
-			Status: StatusFail,
-			Checks: make(map[string]CheckResult),
-		}
+		return health.HealthCheckDetailedResponse{Status: health.HealthCheckDetailedResponseStatusFail}
 	}
 
-	results := CheckResults{
-		Status: StatusPass,
-		Checks: make(map[string]CheckResult),
-	}
+	checks := map[string]check{}
+	status := health.HealthCheckDetailedResponseStatusPass
 
 	for _, checker := range s.checkers {
-		result := CheckResult{
-			Name:   checker.Name(),
-			Status: StatusPass,
-		}
+		result := check{Status: health.HealthCheckDetailedResponseChecksStatusPass}
 
 		if err := checker.Check(ctx); err != nil {
-			result.Status = StatusFail
-			result.Message = err.Error()
-			results.Status = StatusFail
+			message := err.Error()
+			result.Status = health.HealthCheckDetailedResponseChecksStatusFail
+			result.Message = &message
+			status = health.HealthCheckDetailedResponseStatusFail
 		}
 
-		results.Checks[checker.Name()] = result
+		checks[checker.Name()] = result
 	}
 
-	return results
+	response := health.HealthCheckDetailedResponse{Status: status}
+	if len(checks) > 0 {
+		response.Checks = &checks
+	}
+
+	return response
 }
 
 func (s *Service) StartDraining() {

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -16,7 +16,7 @@ import (
 
 	firebase "firebase.google.com/go/v4"
 	"firebase.google.com/go/v4/auth"
-	"github.com/pressly/goose"
+	"github.com/pressly/goose/v3"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/rs/cors"
 	"google.golang.org/api/option"

--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,6 @@ require (
 	firebase.google.com/go/v4 v4.21.0
 	github.com/lib/pq v1.12.3
 	github.com/oapi-codegen/runtime v1.6.0
-	github.com/pressly/goose v2.7.0+incompatible
 	github.com/pressly/goose/v3 v3.27.3
 	github.com/prometheus/client_golang v1.24.1
 	github.com/rs/cors v1.11.1

--- a/go.sum
+++ b/go.sum
@@ -695,8 +695,6 @@ github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 h1:Jamvg5psRI
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/power-devops/perfstat v0.0.0-20240221224432-82ca36839d55 h1:o4JXh1EVt9k/+g42oCprj/FisM4qX9L3sZB3upGN2ZU=
 github.com/power-devops/perfstat v0.0.0-20240221224432-82ca36839d55/go.mod h1:OmDBASR4679mdNQnz2pUhc2G8CO2JrUAVFDRBDP/hJE=
-github.com/pressly/goose v2.7.0+incompatible h1:PWejVEv07LCerQEzMMeAtjuyCKbyprZ/LBa6K5P0OCQ=
-github.com/pressly/goose v2.7.0+incompatible/go.mod h1:m+QHWCqxR3k8D9l7qfzuC/djtlfzxr34mozWDYEu1z8=
 github.com/pressly/goose/v3 v3.27.3 h1:pIglVHjw99r4e/hDHHwbl9vfOsDMqUokfkXo6+n/RxA=
 github.com/pressly/goose/v3 v3.27.3/go.mod h1:Dag+xpV6o20HR2LFY1j0q6MDwc3f7vPUFDA77R+0yGY=
 github.com/prometheus/client_golang v1.24.1 h1:JnJkREXzWxUdCuPFpIWZiPispT9xVV59uiuyR2bPlnU=

--- a/pkg/entity/model.go
+++ b/pkg/entity/model.go
@@ -89,12 +89,10 @@ func (GameTable) TableName() string {
 }
 
 type Score struct {
-	ID        int        `gorm:"primaryKey"`
-	PlayerID  int        `gorm:"not null;uniqueIndex:idx_player_table"`
-	TableID   int        `gorm:"not null;uniqueIndex:idx_player_table"`
-	Score     int        `gorm:"not null"`
-	Players   []*Player  `gorm:"many2many:table_players"`
-	GameTable *GameTable `gorm:"foreignKey:TableID"`
+	ID        int `gorm:"primaryKey"`
+	PlayerID  int `gorm:"not null;uniqueIndex:idx_player_table"`
+	TableID   int `gorm:"not null;uniqueIndex:idx_player_table"`
+	Score     int `gorm:"not null"`
 	CreatedAt time.Time
 	UpdatedAt time.Time
 }

--- a/pkg/setup/assign_tables.go
+++ b/pkg/setup/assign_tables.go
@@ -86,16 +86,8 @@ func AssignTables(teamSetup TeamSetup, seed int64) (TeamsPlayersMapping, error) 
 			tables[i] = make([]Player, 0, teamSetup.TableSize)
 		}
 
-		tableIDs := make([]int, 0, numberOfTables)
-
-		for tableID := range teamSetup.Teams {
-			tableIDs = append(tableIDs, tableID)
-		}
-
-		sort.Ints(tableIDs)
-
 		for range teamSetup.TableSize {
-			for tableID := range tableIDs {
+			for tableID := range numberOfTeams {
 				assignedToTable := tables[tableID]
 				for i, playerToAssign := range playersToAssign {
 					containsSameTeamID := slices.ContainsFunc(assignedToTable, func(p Player) bool {


### PR DESCRIPTION
- drop goose v2 dep; run migrations via goose/v3 (already a tool dep)
- remove dead tableIDs slice + sort in AssignTables (only length used)
- remove unused Score.Players and Score.GameTable GORM associations
- collapse health domain types into generated wire types, dropping the handler remap; wire output unchanged