### PR TITLE
refactor: apply ponytail audit cuts and fix latent middleware bugs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -358,14 +358,6 @@ Required in `.env`:
 - `DATABASE_URL` - PostgreSQL connection string
 - `DB_MIGRATION_DIR` - Path to migrations directory (e.g., `db_migration`)
 
-Optional (with defaults):
-
-- `MAX_REQUEST_SIZE` - Default: `1048576` (1MB in bytes)
-- `DB_MAX_OPEN_CONNS` - Default: `25`
-- `DB_MAX_IDLE_CONNS` - Default: `5`
-- `DB_CONN_MAX_LIFETIME` - Default: `5m`
-- `DB_CONN_MAX_IDLE_TIME` - Default: `10m`
-
 ## CI/CD
 
 GitHub Actions workflows in `.github/workflows/`:

--- a/README.md
+++ b/README.md
@@ -66,12 +66,6 @@ Required variables (set by `make setup` in `.env` for local development):
 | `DATABASE_URL`     | PostgreSQL connection string                                       |
 | `DB_MIGRATION_DIR` | Directory for database migrations                                  |
 
-Optional variables (with defaults):
-
-| Variable           | Default   | Description                          |
-|--------------------|-----------|--------------------------------------|
-| `MAX_REQUEST_SIZE` | `1048576` | Max request body size in bytes (1MB) |
-
 ## Development
 
 ```sh

--- a/api/handlers/error_response.go
+++ b/api/handlers/error_response.go
@@ -2,8 +2,12 @@ package handlers
 
 import (
 	"encoding/json"
+	"errors"
 	"log/slog"
 	"net/http"
+
+	"github.com/henok321/knobel-manager-service/api/middleware"
+	"github.com/henok321/knobel-manager-service/pkg/apperror"
 )
 
 type ErrorResponse struct {
@@ -16,5 +20,46 @@ func JSONError(w http.ResponseWriter, errorMessage string, statusCode int) {
 	w.WriteHeader(statusCode)
 	if err := json.NewEncoder(w).Encode(&ErrorResponse{Error: errorMessage}); err != nil {
 		slog.Error("Failed to encode error response", "error", err)
+	}
+}
+
+func userSub(w http.ResponseWriter, r *http.Request) (string, bool) {
+	user, ok := middleware.UserFromContext(r.Context())
+	if !ok {
+		JSONError(w, "User context not found", http.StatusInternalServerError)
+		return "", false
+	}
+
+	return user.Sub, true
+}
+
+func respondError(w http.ResponseWriter, err error) {
+	switch {
+	case errors.Is(err, apperror.ErrNotOwner):
+		JSONError(w, "Forbidden", http.StatusForbidden)
+	case errors.Is(err, apperror.ErrGameNotFound):
+		JSONError(w, "Game not found", http.StatusNotFound)
+	case errors.Is(err, apperror.ErrTeamNotFound):
+		JSONError(w, "Team not found", http.StatusNotFound)
+	case errors.Is(err, apperror.ErrPlayerNotFound):
+		JSONError(w, "Player not found", http.StatusNotFound)
+	case errors.Is(err, apperror.ErrRoundOrTableNotFound):
+		JSONError(w, "Round or table not found", http.StatusNotFound)
+	case errors.Is(err, apperror.ErrInvalidScore):
+		JSONError(w, "Invalid score", http.StatusBadRequest)
+	case errors.Is(err, apperror.ErrTeamSizeNotAllowed):
+		JSONError(w, "Invalid team size", http.StatusBadRequest)
+	case errors.Is(err, apperror.ErrInvalidGameSetup):
+		JSONError(w, "Invalid game setup", http.StatusConflict)
+	case errors.Is(err, apperror.ErrGameIncomplete):
+		JSONError(w, "Game is complete", http.StatusConflict)
+	case errors.Is(err, apperror.ErrAlreadyOwner):
+		JSONError(w, "Already an owner", http.StatusConflict)
+	case errors.Is(err, apperror.ErrLastOwner):
+		JSONError(w, "Cannot remove the last owner", http.StatusConflict)
+	case errors.Is(err, apperror.ErrUserNotFound):
+		JSONError(w, "No user found for the given email", http.StatusUnprocessableEntity)
+	default:
+		JSONError(w, "Internal server error", http.StatusInternalServerError)
 	}
 }

--- a/api/handlers/games_handler.go
+++ b/api/handlers/games_handler.go
@@ -3,7 +3,6 @@ package handlers
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"log/slog"
 	"net/http"
@@ -12,7 +11,6 @@ import (
 
 	"github.com/henok321/knobel-manager-service/api/middleware"
 	"github.com/henok321/knobel-manager-service/gen/api"
-	"github.com/henok321/knobel-manager-service/pkg/apperror"
 	"github.com/henok321/knobel-manager-service/pkg/entity"
 	"github.com/henok321/knobel-manager-service/pkg/game"
 )
@@ -69,17 +67,14 @@ func (h *GamesHandler) enrichOwnerEmails(ctx context.Context, games ...*api.Game
 func (h *GamesHandler) GetGames(writer http.ResponseWriter, request *http.Request) {
 	ctx := request.Context()
 
-	userContext, ok := middleware.UserFromContext(ctx)
+	sub, ok := userSub(writer, request)
 	if !ok {
-		JSONError(writer, "User context not found", http.StatusInternalServerError)
 		return
 	}
 
-	sub := userContext.Sub
-
 	allGames, err := h.gamesService.FindAllByOwner(ctx, sub)
 	if err != nil {
-		JSONError(writer, "Internal server error", http.StatusInternalServerError)
+		respondError(writer, err)
 		return
 	}
 
@@ -108,25 +103,14 @@ func (h *GamesHandler) GetGames(writer http.ResponseWriter, request *http.Reques
 func (h *GamesHandler) GetGame(writer http.ResponseWriter, request *http.Request, gameID int) {
 	ctx := request.Context()
 
-	userContext, ok := middleware.UserFromContext(ctx)
+	sub, ok := userSub(writer, request)
 	if !ok {
-		JSONError(writer, "User context not found", http.StatusInternalServerError)
 		return
 	}
 
-	sub := userContext.Sub
-
 	gameByID, err := h.gamesService.FindByID(ctx, gameID, sub)
 	if err != nil {
-		switch {
-		case errors.Is(err, apperror.ErrNotOwner):
-			JSONError(writer, "forbidden", http.StatusForbidden)
-		case errors.Is(err, entity.ErrGameNotFound):
-			JSONError(writer, "Game not found", http.StatusNotFound)
-		default:
-			JSONError(writer, "Internal server error", http.StatusInternalServerError)
-		}
-
+		respondError(writer, err)
 		return
 	}
 
@@ -145,13 +129,10 @@ func (h *GamesHandler) GetGame(writer http.ResponseWriter, request *http.Request
 func (h *GamesHandler) CreateGame(writer http.ResponseWriter, request *http.Request) {
 	ctx := request.Context()
 
-	userContext, ok := middleware.UserFromContext(ctx)
+	sub, ok := userSub(writer, request)
 	if !ok {
-		JSONError(writer, "User context not found", http.StatusInternalServerError)
 		return
 	}
-
-	sub := userContext.Sub
 
 	gameCreateRequest := api.GameCreateRequest{}
 
@@ -168,7 +149,7 @@ func (h *GamesHandler) CreateGame(writer http.ResponseWriter, request *http.Requ
 
 	createdGame, err := h.gamesService.CreateGame(ctx, sub, &gameCreateRequest)
 	if err != nil {
-		JSONError(writer, "Internal server error", http.StatusInternalServerError)
+		respondError(writer, err)
 		return
 	}
 
@@ -190,13 +171,10 @@ func (h *GamesHandler) CreateGame(writer http.ResponseWriter, request *http.Requ
 func (h *GamesHandler) UpdateGame(writer http.ResponseWriter, request *http.Request, gameID int) {
 	ctx := request.Context()
 
-	userContext, ok := middleware.UserFromContext(ctx)
+	sub, ok := userSub(writer, request)
 	if !ok {
-		JSONError(writer, "User context not found", http.StatusInternalServerError)
 		return
 	}
-
-	sub := userContext.Sub
 
 	gameUpdateRequest := api.GameUpdateRequest{}
 
@@ -213,19 +191,7 @@ func (h *GamesHandler) UpdateGame(writer http.ResponseWriter, request *http.Requ
 
 	updatedGame, err := h.gamesService.UpdateGame(ctx, gameID, sub, gameUpdateRequest)
 	if err != nil {
-		switch {
-		case errors.Is(err, apperror.ErrNotOwner):
-			JSONError(writer, "Not owner", http.StatusForbidden)
-		case errors.Is(err, entity.ErrGameNotFound):
-			JSONError(writer, "Game not found", http.StatusNotFound)
-		case errors.Is(err, apperror.ErrInvalidGameSetup):
-			JSONError(writer, "Invalid game setup", http.StatusConflict)
-		case errors.Is(err, apperror.ErrGameIncomplete):
-			JSONError(writer, "Game is complete", http.StatusConflict)
-		default:
-			JSONError(writer, "Internal server error", http.StatusInternalServerError)
-		}
-
+		respondError(writer, err)
 		return
 	}
 
@@ -246,9 +212,8 @@ func (h *GamesHandler) UpdateGame(writer http.ResponseWriter, request *http.Requ
 func (h *GamesHandler) AddOwner(writer http.ResponseWriter, request *http.Request, gameID int) {
 	ctx := request.Context()
 
-	userContext, ok := middleware.UserFromContext(ctx)
+	sub, ok := userSub(writer, request)
 	if !ok {
-		JSONError(writer, "User context not found", http.StatusInternalServerError)
 		return
 	}
 
@@ -264,21 +229,9 @@ func (h *GamesHandler) AddOwner(writer http.ResponseWriter, request *http.Reques
 		return
 	}
 
-	updatedGame, err := h.gamesService.AddOwner(ctx, gameID, userContext.Sub, body.Email)
+	updatedGame, err := h.gamesService.AddOwner(ctx, gameID, sub, body.Email)
 	if err != nil {
-		switch {
-		case errors.Is(err, apperror.ErrNotOwner):
-			JSONError(writer, "forbidden", http.StatusForbidden)
-		case errors.Is(err, entity.ErrGameNotFound):
-			JSONError(writer, "Game not found", http.StatusNotFound)
-		case errors.Is(err, apperror.ErrAlreadyOwner):
-			JSONError(writer, "Already an owner", http.StatusConflict)
-		case errors.Is(err, apperror.ErrUserNotFound):
-			JSONError(writer, "No user found for the given email", http.StatusUnprocessableEntity)
-		default:
-			JSONError(writer, "Internal server error", http.StatusInternalServerError)
-		}
-
+		respondError(writer, err)
 		return
 	}
 
@@ -296,25 +249,14 @@ func (h *GamesHandler) AddOwner(writer http.ResponseWriter, request *http.Reques
 func (h *GamesHandler) RemoveOwner(writer http.ResponseWriter, request *http.Request, gameID int, ownerSub string) {
 	ctx := request.Context()
 
-	userContext, ok := middleware.UserFromContext(ctx)
+	sub, ok := userSub(writer, request)
 	if !ok {
-		JSONError(writer, "User context not found", http.StatusInternalServerError)
 		return
 	}
 
-	updatedGame, err := h.gamesService.RemoveOwner(ctx, gameID, userContext.Sub, ownerSub)
+	updatedGame, err := h.gamesService.RemoveOwner(ctx, gameID, sub, ownerSub)
 	if err != nil {
-		switch {
-		case errors.Is(err, apperror.ErrNotOwner):
-			JSONError(writer, "forbidden", http.StatusForbidden)
-		case errors.Is(err, entity.ErrGameNotFound):
-			JSONError(writer, "Game or owner not found", http.StatusNotFound)
-		case errors.Is(err, apperror.ErrLastOwner):
-			JSONError(writer, "Cannot remove the last owner", http.StatusConflict)
-		default:
-			JSONError(writer, "Internal server error", http.StatusInternalServerError)
-		}
-
+		respondError(writer, err)
 		return
 	}
 
@@ -332,24 +274,13 @@ func (h *GamesHandler) RemoveOwner(writer http.ResponseWriter, request *http.Req
 func (h *GamesHandler) DeleteGame(writer http.ResponseWriter, request *http.Request, gameID int) {
 	ctx := request.Context()
 
-	userContext, ok := middleware.UserFromContext(ctx)
+	sub, ok := userSub(writer, request)
 	if !ok {
-		JSONError(writer, "User context not found", http.StatusInternalServerError)
 		return
 	}
 
-	sub := userContext.Sub
-
 	if err := h.gamesService.DeleteGame(ctx, gameID, sub); err != nil {
-		switch {
-		case errors.Is(err, apperror.ErrNotOwner):
-			JSONError(writer, "forbidden", http.StatusForbidden)
-		case errors.Is(err, entity.ErrGameNotFound):
-			JSONError(writer, "Game not found", http.StatusNotFound)
-		default:
-			JSONError(writer, "Internal server error", http.StatusInternalServerError)
-		}
-
+		respondError(writer, err)
 		return
 	}
 
@@ -359,25 +290,14 @@ func (h *GamesHandler) DeleteGame(writer http.ResponseWriter, request *http.Requ
 func (h *GamesHandler) SetupGame(writer http.ResponseWriter, request *http.Request, gameID int) {
 	ctx := request.Context()
 
-	userContext, ok := middleware.UserFromContext(ctx)
+	sub, ok := userSub(writer, request)
 	if !ok {
-		JSONError(writer, "User context not found", http.StatusInternalServerError)
 		return
 	}
 
-	sub := userContext.Sub
-
 	gameToAssign, err := h.gamesService.FindByID(ctx, gameID, sub)
 	if err != nil {
-		switch {
-		case errors.Is(err, apperror.ErrNotOwner):
-			JSONError(writer, "forbidden", http.StatusForbidden)
-		case errors.Is(err, entity.ErrGameNotFound):
-			JSONError(writer, "Game not found", http.StatusNotFound)
-		default:
-			JSONError(writer, "Internal server error", http.StatusInternalServerError)
-		}
-
+		respondError(writer, err)
 		return
 	}
 
@@ -393,7 +313,7 @@ func (h *GamesHandler) SetupGame(writer http.ResponseWriter, request *http.Reque
 
 	err = h.gamesService.AssignTables(ctx, gameToAssign)
 	if err != nil {
-		JSONError(writer, "Internal server error", http.StatusInternalServerError)
+		respondError(writer, err)
 		return
 	}
 

--- a/api/handlers/players_handler.go
+++ b/api/handlers/players_handler.go
@@ -2,14 +2,11 @@ package handlers
 
 import (
 	"encoding/json"
-	"errors"
 	"fmt"
 	"log/slog"
 	"net/http"
 
-	"github.com/henok321/knobel-manager-service/api/middleware"
 	"github.com/henok321/knobel-manager-service/gen/api"
-	"github.com/henok321/knobel-manager-service/pkg/apperror"
 	"github.com/henok321/knobel-manager-service/pkg/player"
 )
 
@@ -26,13 +23,10 @@ func NewPlayersHandler(service *player.PlayersService) *PlayersHandler {
 func (h *PlayersHandler) CreatePlayer(writer http.ResponseWriter, request *http.Request, gameID, teamID int) {
 	ctx := request.Context()
 
-	userContext, ok := middleware.UserFromContext(ctx)
+	sub, ok := userSub(writer, request)
 	if !ok {
-		JSONError(writer, "User context not found", http.StatusInternalServerError)
 		return
 	}
-
-	sub := userContext.Sub
 
 	playersRequest := api.PlayersRequest{}
 
@@ -48,15 +42,7 @@ func (h *PlayersHandler) CreatePlayer(writer http.ResponseWriter, request *http.
 
 	createPlayer, err := h.playersService.CreatePlayer(ctx, playersRequest, teamID, sub)
 	if err != nil {
-		switch {
-		case errors.Is(err, apperror.ErrTeamNotFound):
-			JSONError(writer, "Team not found", http.StatusNotFound)
-		case errors.Is(err, apperror.ErrNotOwner):
-			JSONError(writer, "forbidden", http.StatusForbidden)
-		default:
-			JSONError(writer, "Internal server error", http.StatusInternalServerError)
-		}
-
+		respondError(writer, err)
 		return
 	}
 
@@ -76,13 +62,10 @@ func (h *PlayersHandler) CreatePlayer(writer http.ResponseWriter, request *http.
 func (h *PlayersHandler) UpdatePlayer(writer http.ResponseWriter, request *http.Request, _ /* gameID */, _ /* teamID */, playerID int) {
 	ctx := request.Context()
 
-	userContext, ok := middleware.UserFromContext(ctx)
+	sub, ok := userSub(writer, request)
 	if !ok {
-		JSONError(writer, "User context not found", http.StatusInternalServerError)
 		return
 	}
-
-	sub := userContext.Sub
 
 	playersRequest := api.PlayersRequest{}
 
@@ -98,15 +81,7 @@ func (h *PlayersHandler) UpdatePlayer(writer http.ResponseWriter, request *http.
 
 	updatePlayer, err := h.playersService.UpdatePlayer(ctx, playerID, playersRequest, sub)
 	if err != nil {
-		switch {
-		case errors.Is(err, apperror.ErrTeamNotFound), errors.Is(err, apperror.ErrPlayerNotFound):
-			JSONError(writer, err.Error(), http.StatusNotFound)
-		case errors.Is(err, apperror.ErrNotOwner):
-			JSONError(writer, "forbidden", http.StatusForbidden)
-		default:
-			JSONError(writer, "Internal server error", http.StatusInternalServerError)
-		}
-
+		respondError(writer, err)
 		return
 	}
 
@@ -123,27 +98,13 @@ func (h *PlayersHandler) UpdatePlayer(writer http.ResponseWriter, request *http.
 }
 
 func (h *PlayersHandler) DeletePlayer(writer http.ResponseWriter, request *http.Request, _ /* gameID */, _ /* teamID */, playerID int) {
-	ctx := request.Context()
-
-	userContext, ok := middleware.UserFromContext(ctx)
+	sub, ok := userSub(writer, request)
 	if !ok {
-		JSONError(writer, "User context not found", http.StatusInternalServerError)
 		return
 	}
 
-	sub := userContext.Sub
-
-	err := h.playersService.DeletePlayer(ctx, playerID, sub)
-	if err != nil {
-		switch {
-		case errors.Is(err, apperror.ErrPlayerNotFound):
-			JSONError(writer, err.Error(), http.StatusNotFound)
-		case errors.Is(err, apperror.ErrNotOwner):
-			JSONError(writer, "forbidden", http.StatusForbidden)
-		default:
-			JSONError(writer, "Internal server error", http.StatusInternalServerError)
-		}
-
+	if err := h.playersService.DeletePlayer(request.Context(), playerID, sub); err != nil {
+		respondError(writer, err)
 		return
 	}
 

--- a/api/handlers/tables_handler.go
+++ b/api/handlers/tables_handler.go
@@ -2,14 +2,10 @@ package handlers
 
 import (
 	"encoding/json"
-	"errors"
 	"log/slog"
 	"net/http"
 
-	"github.com/henok321/knobel-manager-service/api/middleware"
 	"github.com/henok321/knobel-manager-service/gen/api"
-	"github.com/henok321/knobel-manager-service/pkg/apperror"
-	"github.com/henok321/knobel-manager-service/pkg/entity"
 	"github.com/henok321/knobel-manager-service/pkg/game"
 	"github.com/henok321/knobel-manager-service/pkg/table"
 )
@@ -26,27 +22,15 @@ func NewTablesHandler(gamesService *game.GamesService, tablesService *table.Tabl
 func (t *TablesHandler) GetGameTables(writer http.ResponseWriter, request *http.Request, gameID int) {
 	ctx := request.Context()
 
-	userContext, ok := middleware.UserFromContext(ctx)
+	sub, ok := userSub(writer, request)
 	if !ok {
-		JSONError(writer, "User context not found", http.StatusInternalServerError)
 		return
 	}
 
-	sub := userContext.Sub
-
 	gameByID, err := t.gamesService.FindByID(ctx, gameID, sub)
 	if err != nil {
-		switch {
-		case errors.Is(err, apperror.ErrNotOwner):
-			JSONError(writer, "Forbidden", http.StatusForbidden)
-			return
-		case errors.Is(err, entity.ErrGameNotFound):
-			JSONError(writer, "Game not found", http.StatusNotFound)
-			return
-		default:
-			JSONError(writer, err.Error(), http.StatusInternalServerError)
-			return
-		}
+		respondError(writer, err)
+		return
 	}
 
 	apiTables := make([]api.Table, 0)
@@ -72,27 +56,15 @@ func (t *TablesHandler) GetGameTables(writer http.ResponseWriter, request *http.
 func (t *TablesHandler) GetTables(writer http.ResponseWriter, request *http.Request, gameID, roundNumber int) {
 	ctx := request.Context()
 
-	userContext, ok := middleware.UserFromContext(ctx)
+	sub, ok := userSub(writer, request)
 	if !ok {
-		JSONError(writer, "User context not found", http.StatusInternalServerError)
 		return
 	}
 
-	sub := userContext.Sub
-
 	gameByID, err := t.gamesService.FindByID(ctx, gameID, sub)
 	if err != nil {
-		switch {
-		case errors.Is(err, apperror.ErrNotOwner):
-			JSONError(writer, "Forbidden", http.StatusForbidden)
-			return
-		case errors.Is(err, entity.ErrGameNotFound):
-			JSONError(writer, "Game not found", http.StatusNotFound)
-			return
-		default:
-			JSONError(writer, err.Error(), http.StatusInternalServerError)
-			return
-		}
+		respondError(writer, err)
+		return
 	}
 
 	for _, round := range gameByID.Rounds {
@@ -123,27 +95,15 @@ func (t *TablesHandler) GetTables(writer http.ResponseWriter, request *http.Requ
 func (t *TablesHandler) GetTable(writer http.ResponseWriter, request *http.Request, gameID, roundNumber, tableNumber int) {
 	ctx := request.Context()
 
-	userContext, ok := middleware.UserFromContext(ctx)
+	sub, ok := userSub(writer, request)
 	if !ok {
-		JSONError(writer, "User context not found", http.StatusInternalServerError)
 		return
 	}
 
-	sub := userContext.Sub
-
 	gameByID, err := t.gamesService.FindByID(ctx, gameID, sub)
 	if err != nil {
-		switch {
-		case errors.Is(err, apperror.ErrNotOwner):
-			JSONError(writer, "Forbidden", http.StatusForbidden)
-			return
-		case errors.Is(err, entity.ErrGameNotFound):
-			JSONError(writer, "Game not found", http.StatusNotFound)
-			return
-		default:
-			JSONError(writer, err.Error(), http.StatusInternalServerError)
-			return
-		}
+		respondError(writer, err)
+		return
 	}
 
 	for _, round := range gameByID.Rounds {
@@ -171,13 +131,10 @@ func (t *TablesHandler) GetTable(writer http.ResponseWriter, request *http.Reque
 func (t *TablesHandler) UpdateScores(writer http.ResponseWriter, request *http.Request, gameID, roundNumber, tableNumber int) {
 	ctx := request.Context()
 
-	userContext, ok := middleware.UserFromContext(ctx)
+	sub, ok := userSub(writer, request)
 	if !ok {
-		JSONError(writer, "User context not found", http.StatusInternalServerError)
 		return
 	}
-
-	sub := userContext.Sub
 
 	scoresRequest := api.ScoresRequest{}
 
@@ -193,15 +150,7 @@ func (t *TablesHandler) UpdateScores(writer http.ResponseWriter, request *http.R
 
 	updatedTable, err := t.tablesService.UpdateScore(ctx, gameID, roundNumber, tableNumber, sub, scoresRequest)
 	if err != nil {
-		switch {
-		case errors.Is(err, apperror.ErrInvalidScore):
-			JSONError(writer, "Invalid score", http.StatusBadRequest)
-		case errors.Is(err, apperror.ErrRoundOrTableNotFound):
-			JSONError(writer, "Round or table not found", http.StatusNotFound)
-		default:
-			JSONError(writer, err.Error(), http.StatusInternalServerError)
-		}
-
+		respondError(writer, err)
 		return
 	}
 

--- a/api/handlers/teams_handler.go
+++ b/api/handlers/teams_handler.go
@@ -2,15 +2,11 @@ package handlers
 
 import (
 	"encoding/json"
-	"errors"
 	"log/slog"
 	"net/http"
 	"strconv"
 
-	"github.com/henok321/knobel-manager-service/api/middleware"
 	"github.com/henok321/knobel-manager-service/gen/api"
-	"github.com/henok321/knobel-manager-service/pkg/apperror"
-	"github.com/henok321/knobel-manager-service/pkg/entity"
 	"github.com/henok321/knobel-manager-service/pkg/team"
 )
 
@@ -25,13 +21,10 @@ func NewTeamsHandler(service *team.TeamsService) *TeamsHandler {
 func (t *TeamsHandler) CreateTeam(writer http.ResponseWriter, request *http.Request, gameID int) {
 	ctx := request.Context()
 
-	userContext, ok := middleware.UserFromContext(ctx)
+	sub, ok := userSub(writer, request)
 	if !ok {
-		JSONError(writer, "User context not found", http.StatusInternalServerError)
 		return
 	}
-
-	sub := userContext.Sub
 
 	teamsRequest := api.TeamsRequest{}
 
@@ -47,18 +40,7 @@ func (t *TeamsHandler) CreateTeam(writer http.ResponseWriter, request *http.Requ
 
 	createdTeam, err := t.service.CreateTeam(ctx, gameID, sub, teamsRequest)
 	if err != nil {
-		switch {
-		case errors.Is(err, entity.ErrGameNotFound):
-			JSONError(writer, "Game not found", http.StatusNotFound)
-		case errors.Is(err, apperror.ErrNotOwner):
-			JSONError(writer, "Forbidden", http.StatusForbidden)
-		case errors.Is(err, apperror.ErrTeamSizeNotAllowed):
-			JSONError(writer, "Invalid team size", http.StatusBadRequest)
-
-		default:
-			JSONError(writer, err.Error(), http.StatusInternalServerError)
-		}
-
+		respondError(writer, err)
 		return
 	}
 
@@ -78,13 +60,10 @@ func (t *TeamsHandler) CreateTeam(writer http.ResponseWriter, request *http.Requ
 func (t *TeamsHandler) UpdateTeam(writer http.ResponseWriter, request *http.Request, gameID, teamID int) {
 	ctx := request.Context()
 
-	userContext, ok := middleware.UserFromContext(ctx)
+	sub, ok := userSub(writer, request)
 	if !ok {
-		JSONError(writer, "User context not found", http.StatusInternalServerError)
 		return
 	}
-
-	sub := userContext.Sub
 
 	teamsRequest := api.TeamsRequest{}
 
@@ -100,15 +79,7 @@ func (t *TeamsHandler) UpdateTeam(writer http.ResponseWriter, request *http.Requ
 
 	updatedGame, err := t.service.UpdateTeam(ctx, gameID, sub, teamID, teamsRequest)
 	if err != nil {
-		switch {
-		case errors.Is(err, apperror.ErrNotOwner):
-			JSONError(writer, "Forbidden", http.StatusForbidden)
-		case errors.Is(err, entity.ErrGameNotFound):
-			JSONError(writer, "Game not found", http.StatusNotFound)
-		case errors.Is(err, apperror.ErrTeamNotFound):
-			JSONError(writer, "Team not found", http.StatusNotFound)
-		}
-
+		respondError(writer, err)
 		return
 	}
 
@@ -125,27 +96,13 @@ func (t *TeamsHandler) UpdateTeam(writer http.ResponseWriter, request *http.Requ
 }
 
 func (t *TeamsHandler) DeleteTeam(writer http.ResponseWriter, request *http.Request, gameID, teamID int) {
-	ctx := request.Context()
-
-	userContext, ok := middleware.UserFromContext(ctx)
+	sub, ok := userSub(writer, request)
 	if !ok {
-		JSONError(writer, "User context not found", http.StatusInternalServerError)
 		return
 	}
 
-	sub := userContext.Sub
-
-	err := t.service.DeleteTeam(ctx, gameID, sub, teamID)
-	if err != nil {
-		switch {
-		case errors.Is(err, apperror.ErrNotOwner):
-			JSONError(writer, "Forbidden", http.StatusForbidden)
-		case errors.Is(err, entity.ErrGameNotFound):
-			JSONError(writer, "Game not found", http.StatusNotFound)
-		default:
-			JSONError(writer, err.Error(), http.StatusInternalServerError)
-		}
-
+	if err := t.service.DeleteTeam(request.Context(), gameID, sub, teamID); err != nil {
+		respondError(writer, err)
 		return
 	}
 

--- a/api/middleware/logging.go
+++ b/api/middleware/logging.go
@@ -28,7 +28,7 @@ func RequestLogging(logLevel slog.Level) func(http.Handler) http.Handler {
 		return http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
 			b := make([]byte, 16)
 			_, _ = rand.Read(b)
-			requestLoggingContext := Request{
+			requestLoggingContext := &Request{
 				Method: request.Method,
 				Path:   request.RequestURI,
 				ID:     hex.EncodeToString(b),

--- a/api/middleware/security_headers.go
+++ b/api/middleware/security_headers.go
@@ -2,33 +2,21 @@ package middleware
 
 import (
 	"net/http"
-	"os"
-	"strconv"
 )
 
-const (
-	DefaultMaxRequestSize = 1048576
-)
+const maxRequestSize = 1 << 20
 
 func SecurityHeaders(contentSecurityPolicy string) func(http.Handler) http.Handler {
-	maxSize := DefaultMaxRequestSize
-
-	if maxSizeEnv := os.Getenv("MAX_REQUEST_SIZE"); maxSizeEnv != "" {
-		if size, err := strconv.ParseInt(maxSizeEnv, 10, strconv.IntSize); err == nil && size > 0 {
-			maxSize = int(size)
-		}
-	}
-
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			if r.Method == http.MethodPost || r.Method == http.MethodPut || r.Method == http.MethodPatch {
-				r.Body = http.MaxBytesReader(w, r.Body, int64(maxSize))
+				r.Body = http.MaxBytesReader(w, r.Body, maxRequestSize)
 			}
 
 			w.Header().Set("X-Content-Type-Options", "nosniff")
 			w.Header().Set("X-Frame-Options", "DENY")
 			w.Header().Set("Content-Security-Policy", contentSecurityPolicy)
-			w.Header().Set("Cors-Origin-Resource-Policy", "same-origin")
+			w.Header().Set("Cross-Origin-Resource-Policy", "same-origin")
 			w.Header().Set("Referrer-Policy", "no-referrer")
 			w.Header().Set("Cache-Control", "no-cache")
 

--- a/api/routes/routes.go
+++ b/api/routes/routes.go
@@ -18,14 +18,6 @@ import (
 	"github.com/henok321/knobel-manager-service/pkg/team"
 )
 
-type routeSetup struct {
-	database      *gorm.DB
-	authClient    middleware.FirebaseAuth
-	healthService *healthpkg.Service
-	openAPIConfig []byte
-	swaggerDocs   []byte
-}
-
 type apiServer struct {
 	*handlers.GamesHandler
 	*handlers.TeamsHandler
@@ -34,17 +26,6 @@ type apiServer struct {
 }
 
 var _ api.ServerInterface = (*apiServer)(nil)
-
-func SetupRouter(database *gorm.DB, authClient middleware.FirebaseAuth, healthClient *healthpkg.Service, openAPIConfig, swaggerDocs []byte) *http.ServeMux {
-	instance := routeSetup{
-		database:      database,
-		authClient:    authClient,
-		healthService: healthClient,
-		openAPIConfig: openAPIConfig,
-		swaggerDocs:   swaggerDocs,
-	}
-	return instance.setup()
-}
 
 func chain(mw ...func(http.Handler) http.Handler) func(http.Handler) http.Handler {
 	return func(h http.Handler) http.Handler {
@@ -55,48 +36,38 @@ func chain(mw ...func(http.Handler) http.Handler) func(http.Handler) http.Handle
 	}
 }
 
-func (app *routeSetup) publicEndpoint(handler http.Handler) http.Handler {
-	return chain(
-		middleware.SecurityHeaders("default-src 'self'"),
-		middleware.Metrics(),
-		middleware.RequestLogging(slog.LevelDebug),
-	)(handler)
-}
+func SetupRouter(database *gorm.DB, authClient middleware.FirebaseAuth, healthService *healthpkg.Service, openAPIConfig, swaggerDocs []byte) *http.ServeMux {
+	public := func(csp string) func(http.Handler) http.Handler {
+		return chain(
+			middleware.SecurityHeaders(csp),
+			middleware.Metrics(),
+			middleware.RequestLogging(slog.LevelDebug),
+		)
+	}
 
-func (app *routeSetup) publicSwaggerDocsEndpoint(handler http.Handler) http.Handler {
-	return chain(
-		middleware.SecurityHeaders("default-src 'self'; style-src 'self' https://unpkg.com; script-src 'self' https://unpkg.com 'unsafe-inline'; img-src 'self' data:"),
-		middleware.Metrics(),
-		middleware.RequestLogging(slog.LevelDebug),
-	)(handler)
-}
-
-func (app *routeSetup) authenticatedEndpoint(handler http.Handler) http.Handler {
-	return chain(
+	authenticated := chain(
 		middleware.SecurityHeaders("default-src 'self'"),
 		middleware.Metrics(),
 		middleware.RequestLogging(slog.LevelInfo),
-		middleware.Authentication(app.authClient),
-	)(handler)
-}
+		middleware.Authentication(authClient),
+	)
 
-func (app *routeSetup) setup() *http.ServeMux {
-	gameService := game.NewGamesService(game.NewGamesRepository(app.database), app.authClient)
-	playerService := player.NewPlayersService(player.NewPlayersRepository(app.database), team.NewTeamsRepository(app.database))
-	tableService := table.NewTablesService(table.NewTablesRepository(app.database))
-	teamService := team.NewTeamsService(team.NewTeamsRepository(app.database), game.NewGamesRepository(app.database))
+	gameService := game.NewGamesService(game.NewGamesRepository(database), authClient)
+	playerService := player.NewPlayersService(player.NewPlayersRepository(database), team.NewTeamsRepository(database))
+	tableService := table.NewTablesService(table.NewTablesRepository(database))
+	teamService := team.NewTeamsService(team.NewTeamsRepository(database), game.NewGamesRepository(database))
 
-	healthHandler := handlers.NewHealthHandler(app.healthService)
-	openAPIHandler := handlers.NewOpenAPIHandler(app.openAPIConfig, app.swaggerDocs)
-	gamesHandler := handlers.NewGamesHandler(gameService, app.authClient)
+	healthHandler := handlers.NewHealthHandler(healthService)
+	openAPIHandler := handlers.NewOpenAPIHandler(openAPIConfig, swaggerDocs)
+	gamesHandler := handlers.NewGamesHandler(gameService, authClient)
 	playersHandler := handlers.NewPlayersHandler(playerService)
 	tablesHandler := handlers.NewTablesHandler(gameService, tableService)
 	teamsHandler := handlers.NewTeamsHandler(teamService)
 
 	router := http.NewServeMux()
 
-	router.Handle("/openapi.yaml", app.publicEndpoint(http.HandlerFunc(openAPIHandler.GetOpenAPIConfig)))
-	router.Handle("/docs", app.publicSwaggerDocsEndpoint(http.HandlerFunc(openAPIHandler.GetSwaggerDocs)))
+	router.Handle("/openapi.yaml", public("default-src 'self'")(http.HandlerFunc(openAPIHandler.GetOpenAPIConfig)))
+	router.Handle("/docs", public("default-src 'self'; style-src 'self' https://unpkg.com; script-src 'self' https://unpkg.com 'unsafe-inline'; img-src 'self' data:")(http.HandlerFunc(openAPIHandler.GetSwaggerDocs)))
 
 	handleValidationErrors := func(w http.ResponseWriter, _ *http.Request, err error) {
 		handlers.JSONError(w, err.Error(), http.StatusBadRequest)
@@ -104,13 +75,13 @@ func (app *routeSetup) setup() *http.ServeMux {
 
 	health.HandlerWithOptions(healthHandler, health.StdHTTPServerOptions{
 		BaseRouter:  router,
-		Middlewares: []health.MiddlewareFunc{app.publicEndpoint},
+		Middlewares: []health.MiddlewareFunc{public("default-src 'self'")},
 	})
 
 	api.HandlerWithOptions(&apiServer{gamesHandler, teamsHandler, playersHandler, tablesHandler}, api.StdHTTPServerOptions{
 		BaseRouter:       router,
 		ErrorHandlerFunc: handleValidationErrors,
-		Middlewares:      []api.MiddlewareFunc{app.authenticatedEndpoint},
+		Middlewares:      []api.MiddlewareFunc{authenticated},
 	})
 
 	return router

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -10,7 +10,6 @@ import (
 	"os"
 	"os/signal"
 	"path/filepath"
-	"strconv"
 	"syscall"
 	"time"
 
@@ -27,24 +26,6 @@ import (
 	"github.com/henok321/knobel-manager-service/api/logging"
 	"github.com/henok321/knobel-manager-service/api/routes"
 )
-
-func getEnvAsInt(key string, defaultValue int) int {
-	if value := os.Getenv(key); value != "" {
-		if intValue, err := strconv.Atoi(value); err == nil {
-			return intValue
-		}
-	}
-	return defaultValue
-}
-
-func getEnvAsDuration(key string, defaultValue time.Duration) time.Duration {
-	if value := os.Getenv(key); value != "" {
-		if duration, err := time.ParseDuration(value); err == nil {
-			return duration
-		}
-	}
-	return defaultValue
-}
 
 func init() {
 	switch os.Getenv("ENVIRONMENT") {
@@ -101,17 +82,10 @@ func setupDatabase() (*gorm.DB, *sql.DB, error) {
 		return nil, nil, err
 	}
 
-	maxOpenConns := getEnvAsInt("DB_MAX_OPEN_CONNS", 25)
-	maxIdleConns := getEnvAsInt("DB_MAX_IDLE_CONNS", 5)
-	connMaxLifetime := getEnvAsDuration("DB_CONN_MAX_LIFETIME", 5*time.Minute)
-	connMaxIdleTime := getEnvAsDuration("DB_CONN_MAX_IDLE_TIME", 10*time.Minute)
-
-	sqlDB.SetMaxOpenConns(maxOpenConns)
-	sqlDB.SetMaxIdleConns(maxIdleConns)
-	sqlDB.SetConnMaxLifetime(connMaxLifetime)
-	sqlDB.SetConnMaxIdleTime(connMaxIdleTime)
-
-	slog.Info("Database connection pool configured", "maxOpenConns", maxOpenConns, "maxIdleConns", maxIdleConns, "connMaxLifetime", connMaxLifetime, "connMaxIdleTime", connMaxIdleTime)
+	sqlDB.SetMaxOpenConns(25)
+	sqlDB.SetMaxIdleConns(5)
+	sqlDB.SetConnMaxLifetime(5 * time.Minute)
+	sqlDB.SetConnMaxIdleTime(10 * time.Minute)
 
 	return gormDB, sqlDB, nil
 }
@@ -216,15 +190,9 @@ func main() {
 	metricsRouter := http.NewServeMux()
 	metricsRouter.Handle("GET /metrics", promhttp.Handler())
 
-	metricsCors := cors.New(cors.Options{
-		AllowedOrigins: []string{"*"},
-		AllowedMethods: []string{"OPTIONS", "GET"},
-		MaxAge:         300, // 5 minutes
-	})
-
 	metricsServer := &http.Server{
 		Addr:         ":9090",
-		Handler:      metricsCors.Handler(metricsRouter),
+		Handler:      metricsRouter,
 		ReadTimeout:  5 * time.Second,
 		WriteTimeout: 10 * time.Second,
 		IdleTimeout:  15 * time.Second,

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ tool (
 
 require (
 	firebase.google.com/go/v4 v4.21.0
-	github.com/lib/pq v1.12.3
+	github.com/jackc/pgx/v5 v5.10.0
 	github.com/oapi-codegen/runtime v1.6.0
 	github.com/pressly/goose/v3 v3.27.3
 	github.com/prometheus/client_golang v1.24.1
@@ -193,7 +193,6 @@ require (
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/jackc/pgpassfile v1.0.0 // indirect
 	github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761 // indirect
-	github.com/jackc/pgx/v5 v5.10.0 // indirect
 	github.com/jackc/puddle/v2 v2.2.2 // indirect
 	github.com/jgautheron/goconst v1.10.0 // indirect
 	github.com/jinzhu/inflection v1.0.0 // indirect

--- a/integrationtests/game_setup_test.go
+++ b/integrationtests/game_setup_test.go
@@ -5,7 +5,7 @@ import (
 	"net/http"
 	"testing"
 
-	_ "github.com/lib/pq"
+	_ "github.com/jackc/pgx/v5/stdlib"
 )
 
 func TestGameSetup(t *testing.T) {
@@ -56,7 +56,7 @@ func TestGameSetup(t *testing.T) {
 	dbConn, teardownDatabase := setupTestDatabase(t)
 	defer teardownDatabase()
 
-	db, err := sql.Open("postgres", dbConn)
+	db, err := sql.Open("pgx", dbConn)
 	if err != nil {
 		t.Fatalf("Failed to open database connection: %v", err)
 	}
@@ -84,7 +84,7 @@ func TestGameSetupMultipleTimes(t *testing.T) {
 	dbConn, teardownDatabase := setupTestDatabase(t)
 	defer teardownDatabase()
 
-	db, err := sql.Open("postgres", dbConn)
+	db, err := sql.Open("pgx", dbConn)
 	if err != nil {
 		t.Fatalf("Failed to open database connection: %v", err)
 	}

--- a/integrationtests/games_test.go
+++ b/integrationtests/games_test.go
@@ -5,7 +5,7 @@ import (
 	"net/http"
 	"testing"
 
-	_ "github.com/lib/pq"
+	_ "github.com/jackc/pgx/v5/stdlib"
 	"github.com/stretchr/testify/assert"
 
 	"github.com/henok321/knobel-manager-service/pkg/entity"
@@ -261,7 +261,7 @@ func TestGames(t *testing.T) {
 	dbConn, teardownDatabase := setupTestDatabase(t)
 	defer teardownDatabase()
 
-	db, err := sql.Open("postgres", dbConn)
+	db, err := sql.Open("pgx", dbConn)
 	if err != nil {
 		t.Fatalf("Failed to open database connection: %v", err)
 	}

--- a/integrationtests/health_test.go
+++ b/integrationtests/health_test.go
@@ -17,7 +17,7 @@ func TestHealthCheck(t *testing.T) {
 		dbConn, teardownDatabase := setupTestDatabase(t)
 		defer teardownDatabase()
 
-		db, err := sql.Open("postgres", dbConn)
+		db, err := sql.Open("pgx", dbConn)
 		if err != nil {
 			t.Fatalf("Failed to open database connection: %v", err)
 		}
@@ -49,7 +49,7 @@ func TestHealthCheck(t *testing.T) {
 		dbConn, teardownDatabase := setupTestDatabase(t)
 		defer teardownDatabase()
 
-		db, err := sql.Open("postgres", dbConn)
+		db, err := sql.Open("pgx", dbConn)
 		if err != nil {
 			t.Fatalf("Failed to open database connection: %v", err)
 		}
@@ -91,7 +91,7 @@ func TestHealthCheck(t *testing.T) {
 	t.Run("readiness check database not available fail", func(t *testing.T) {
 		dbConn, teardownDatabase := setupTestDatabase(t)
 
-		db, err := sql.Open("postgres", dbConn)
+		db, err := sql.Open("pgx", dbConn)
 		if err != nil {
 			t.Fatalf("Failed to open database connection: %v", err)
 		}

--- a/integrationtests/openapi_test.go
+++ b/integrationtests/openapi_test.go
@@ -18,7 +18,7 @@ func TestOpenAPI(t *testing.T) {
 		dbConn, teardownDatabase := setupTestDatabase(t)
 		defer teardownDatabase()
 
-		db, err := sql.Open("postgres", dbConn)
+		db, err := sql.Open("pgx", dbConn)
 		if err != nil {
 			t.Fatalf("Failed to open database connection: %v", err)
 		}
@@ -64,7 +64,7 @@ func TestOpenAPI(t *testing.T) {
 		dbConn, teardownDatabase := setupTestDatabase(t)
 		defer teardownDatabase()
 
-		db, err := sql.Open("postgres", dbConn)
+		db, err := sql.Open("pgx", dbConn)
 		if err != nil {
 			t.Fatalf("Failed to open database connection: %v", err)
 		}

--- a/integrationtests/owners_test.go
+++ b/integrationtests/owners_test.go
@@ -5,7 +5,7 @@ import (
 	"net/http"
 	"testing"
 
-	_ "github.com/lib/pq"
+	_ "github.com/jackc/pgx/v5/stdlib"
 )
 
 func TestOwners(t *testing.T) {
@@ -135,7 +135,7 @@ func TestOwners(t *testing.T) {
 	dbConn, teardownDatabase := setupTestDatabase(t)
 	defer teardownDatabase()
 
-	db, err := sql.Open("postgres", dbConn)
+	db, err := sql.Open("pgx", dbConn)
 	if err != nil {
 		t.Fatalf("Failed to open database connection: %v", err)
 	}

--- a/integrationtests/players_test.go
+++ b/integrationtests/players_test.go
@@ -5,7 +5,7 @@ import (
 	"net/http"
 	"testing"
 
-	_ "github.com/lib/pq"
+	_ "github.com/jackc/pgx/v5/stdlib"
 )
 
 func TestPlayers(t *testing.T) {
@@ -105,7 +105,7 @@ func TestPlayers(t *testing.T) {
 	dbConn, teardownDatabase := setupTestDatabase(t)
 	defer teardownDatabase()
 
-	db, err := sql.Open("postgres", dbConn)
+	db, err := sql.Open("pgx", dbConn)
 	if err != nil {
 		t.Fatalf("Failed to open database connection: %v", err)
 	}

--- a/integrationtests/scores_test.go
+++ b/integrationtests/scores_test.go
@@ -5,7 +5,7 @@ import (
 	"net/http"
 	"testing"
 
-	_ "github.com/lib/pq"
+	_ "github.com/jackc/pgx/v5/stdlib"
 )
 
 func TestScores(t *testing.T) {
@@ -117,7 +117,7 @@ func TestScores(t *testing.T) {
 	dbConn, teardownDatabase := setupTestDatabase(t)
 	defer teardownDatabase()
 
-	db, err := sql.Open("postgres", dbConn)
+	db, err := sql.Open("pgx", dbConn)
 	if err != nil {
 		t.Fatalf("Failed to open database connection: %v", err)
 	}

--- a/integrationtests/tables_test.go
+++ b/integrationtests/tables_test.go
@@ -5,7 +5,7 @@ import (
 	"net/http"
 	"testing"
 
-	_ "github.com/lib/pq"
+	_ "github.com/jackc/pgx/v5/stdlib"
 )
 
 func TestTables(t *testing.T) {
@@ -217,7 +217,7 @@ func TestTables(t *testing.T) {
 	dbConn, teardownDatabase := setupTestDatabase(t)
 	defer teardownDatabase()
 
-	db, err := sql.Open("postgres", dbConn)
+	db, err := sql.Open("pgx", dbConn)
 	if err != nil {
 		t.Fatalf("Failed to open database connection: %v", err)
 	}

--- a/integrationtests/teams_test.go
+++ b/integrationtests/teams_test.go
@@ -5,7 +5,7 @@ import (
 	"net/http"
 	"testing"
 
-	_ "github.com/lib/pq"
+	_ "github.com/jackc/pgx/v5/stdlib"
 )
 
 func TestTeams(t *testing.T) {
@@ -151,7 +151,7 @@ func TestTeams(t *testing.T) {
 	dbConn, teardownDatabase := setupTestDatabase(t)
 	defer teardownDatabase()
 
-	db, err := sql.Open("postgres", dbConn)
+	db, err := sql.Open("pgx", dbConn)
 	if err != nil {
 		t.Fatalf("Failed to open database connection: %v", err)
 	}

--- a/pkg/apperror/error.go
+++ b/pkg/apperror/error.go
@@ -3,6 +3,7 @@ package apperror
 import "errors"
 
 var (
+	ErrGameNotFound         = errors.New("game not found")
 	ErrTeamNotFound         = errors.New("team not found")
 	ErrPlayerNotFound       = errors.New("player not found")
 	ErrNotOwner             = errors.New("user is not the owner of the requested resource")

--- a/pkg/entity/model.go
+++ b/pkg/entity/model.go
@@ -1,11 +1,8 @@
 package entity
 
 import (
-	"errors"
 	"time"
 )
-
-var ErrGameNotFound = errors.New("game not found")
 
 type GameStatus string
 

--- a/pkg/game/repository.go
+++ b/pkg/game/repository.go
@@ -24,9 +24,6 @@ func (r *GamesRepository) FindAllByOwner(ctx context.Context, sub string) ([]ent
 		Preload("Teams.Players.Scores").
 		Preload("Rounds.Tables.Players").
 		Preload("Rounds.Tables.Scores").
-		Preload("Rounds").
-		Preload("Teams").
-		Preload("Teams.Players").
 		Preload("Owners").
 		Find(&games).Error
 	if err != nil {
@@ -44,8 +41,6 @@ func (r *GamesRepository) FindByID(ctx context.Context, id int) (entity.Game, er
 		Preload("Teams.Players.Scores").
 		Preload("Rounds.Tables.Players").
 		Preload("Rounds.Tables.Scores").
-		Preload("Rounds").
-		Preload("Teams").
 		Preload("Owners").
 		First(&game).Error
 	if err != nil {

--- a/pkg/game/service.go
+++ b/pkg/game/service.go
@@ -6,25 +6,21 @@ import (
 	"fmt"
 	"time"
 
-	"firebase.google.com/go/v4/auth"
 	"gorm.io/gorm"
 
+	"github.com/henok321/knobel-manager-service/api/middleware"
 	"github.com/henok321/knobel-manager-service/gen/api"
 	"github.com/henok321/knobel-manager-service/pkg/apperror"
 	"github.com/henok321/knobel-manager-service/pkg/entity"
 	"github.com/henok321/knobel-manager-service/pkg/setup"
 )
 
-type UserLookup interface {
-	GetUserByEmail(ctx context.Context, email string) (*auth.UserRecord, error)
-}
-
 type GamesService struct {
 	repo  *GamesRepository
-	users UserLookup
+	users middleware.FirebaseAuth
 }
 
-func NewGamesService(repo *GamesRepository, users UserLookup) *GamesService {
+func NewGamesService(repo *GamesRepository, users middleware.FirebaseAuth) *GamesService {
 	return &GamesService{repo, users}
 }
 
@@ -36,7 +32,7 @@ func (s *GamesService) FindByID(ctx context.Context, id int, sub string) (entity
 	gameByID, err := s.repo.FindByID(ctx, id)
 	if err != nil {
 		if errors.Is(err, gorm.ErrRecordNotFound) {
-			return entity.Game{}, entity.ErrGameNotFound
+			return entity.Game{}, apperror.ErrGameNotFound
 		}
 
 		return entity.Game{}, err
@@ -66,7 +62,7 @@ func (s *GamesService) UpdateGame(ctx context.Context, id int, sub string, game 
 	gameByID, err := s.repo.FindByID(ctx, id)
 	if err != nil {
 		if errors.Is(err, gorm.ErrRecordNotFound) {
-			return entity.Game{}, entity.ErrGameNotFound
+			return entity.Game{}, apperror.ErrGameNotFound
 		}
 
 		return entity.Game{}, err
@@ -129,7 +125,7 @@ func (s *GamesService) DeleteGame(ctx context.Context, id int, sub string) error
 	gameByID, err := s.repo.FindByID(ctx, id)
 	if err != nil {
 		if errors.Is(err, gorm.ErrRecordNotFound) {
-			return entity.ErrGameNotFound
+			return apperror.ErrGameNotFound
 		}
 
 		return err
@@ -171,7 +167,7 @@ func (s *GamesService) RemoveOwner(ctx context.Context, gameID int, callerSub, t
 	}
 
 	if !entity.IsOwner(game, targetSub) {
-		return entity.Game{}, entity.ErrGameNotFound
+		return entity.Game{}, apperror.ErrGameNotFound
 	}
 
 	if len(game.Owners) <= 1 {

--- a/pkg/team/service.go
+++ b/pkg/team/service.go
@@ -28,7 +28,7 @@ func (s *TeamsService) CreateTeam(ctx context.Context, gameID int, sub string, r
 	gameByID, err := s.gamesRepo.FindByID(ctx, gameID)
 	if err != nil {
 		if errors.Is(err, gorm.ErrRecordNotFound) {
-			return entity.Team{}, entity.ErrGameNotFound
+			return entity.Team{}, apperror.ErrGameNotFound
 		}
 
 		return entity.Team{}, err
@@ -68,7 +68,7 @@ func (s *TeamsService) UpdateTeam(ctx context.Context, gameID int, sub string, t
 	gameByID, err := s.gamesRepo.FindByID(ctx, gameID)
 	if err != nil {
 		if errors.Is(err, gorm.ErrRecordNotFound) {
-			return entity.Team{}, entity.ErrGameNotFound
+			return entity.Team{}, apperror.ErrGameNotFound
 		}
 
 		return entity.Team{}, err
@@ -92,7 +92,7 @@ func (s *TeamsService) DeleteTeam(ctx context.Context, gameID int, sub string, t
 	gameByID, err := s.gamesRepo.FindByID(ctx, gameID)
 	if err != nil {
 		if errors.Is(err, gorm.ErrRecordNotFound) {
-			return entity.ErrGameNotFound
+			return apperror.ErrGameNotFound
 		}
 
 		return err


### PR DESCRIPTION
## Summary

Repo-wide over-engineering audit follow-up (continues #321). Net **-267 lines, -1 direct dependency**, plus three latent bugs found while reading.

### Audit cuts

- **Handler boilerplate**: extracted `userSub` and `respondError` helpers, removing 18 repeated user-context blocks and 10 near-identical `errors.Is` switches. Error messages are now unified (e.g. `Forbidden` everywhere); no integration test pinned the old variants.
- **Routing**: folded the `routeSetup` struct and three one-off middleware wrappers into `SetupRouter`.
- **Metrics server**: dropped the CORS handler — Prometheus scrapes server-to-server; CORS is a browser mechanism.
- **Config knobs**: hardcoded DB pool settings and max request size, removing `DB_MAX_OPEN_CONNS`, `DB_MAX_IDLE_CONNS`, `DB_CONN_MAX_LIFETIME`, `DB_CONN_MAX_IDLE_TIME`, `MAX_REQUEST_SIZE`. ⚠️ **These env vars become no-ops — if Coolify sets any of them in production, say so and I'll restore them.** Docs updated.
- **GORM**: removed `Preload("Rounds")`/`Preload("Teams")`/`Preload("Teams.Players")` — implied by the nested preloads.
- **Interfaces**: replaced the single-use `UserLookup` interface with the existing `middleware.FirebaseAuth`.
- **Errors**: moved `ErrGameNotFound` from `pkg/entity` into `pkg/apperror`, the single home for sentinel errors.
- **Deps**: integration tests now use the pgx stdlib driver (already in the module graph via gorm) instead of `lib/pq`.

### Bug fixes

- `RequestLogging` stored `Request` by value while `RequestFromContext` asserted `*Request` — the assertion always failed, so request id/method/path never appeared in logs.
- `TeamsHandler.UpdateTeam`'s error switch had no `default`, returning an empty 200 on unexpected errors.
- Header typo: `Cors-Origin-Resource-Policy` → `Cross-Origin-Resource-Policy`.

## Test plan

- [x] `go build ./...` clean
- [x] `make lint` — 0 issues
- [x] `go test ./...` — full suite incl. integration tests (testcontainers) green
- [x] pre-commit + pre-push hooks (govulncheck, golangci-lint-full, go-test) passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)