### PR TITLE
fix(security): cross-tenant score IDOR + unbounded metric cardinality DoS

### DIFF
--- a/api/middleware/metrics.go
+++ b/api/middleware/metrics.go
@@ -2,7 +2,6 @@ package middleware
 
 import (
 	"net/http"
-	"strings"
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
@@ -29,9 +28,11 @@ func init() {
 func Metrics() func(http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			handlerName := strings.Trim(r.URL.Path, "/")
+			// Label on the route template, not r.URL.Path: raw paths carry unbounded IDs
+			// (/games/{id}/…) and would let anyone explode metric cardinality → OOM.
+			handlerName := r.Pattern
 			if handlerName == "" {
-				handlerName = "/"
+				handlerName = "unmatched"
 			}
 
 			duration := HTTPRequestDuration.MustCurryWith(prometheus.Labels{"handler": handlerName})

--- a/api/middleware/metrics_test.go
+++ b/api/middleware/metrics_test.go
@@ -1,0 +1,29 @@
+package middleware
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMetricsLabelsUseRoutePatternNotRawPath(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.Handle("GET /games/{gameID}", Metrics()(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})))
+
+	for _, id := range []string{"1", "2", "3"} {
+		req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/games/"+id, nil)
+		mux.ServeHTTP(httptest.NewRecorder(), req)
+	}
+
+	// promhttp lowercases the method label.
+	patternSeries := testutil.ToFloat64(HTTPRequestsTotal.WithLabelValues("GET /games/{gameID}", "get", "200"))
+	assert.Equal(t, 3, int(patternSeries), "distinct IDs must collapse into one series keyed by the route template")
+
+	rawPathSeries := testutil.ToFloat64(HTTPRequestsTotal.WithLabelValues("games/1", "get", "200"))
+	assert.Equal(t, 0, int(rawPathSeries), "raw request paths must never become metric label values")
+}

--- a/go.mod
+++ b/go.mod
@@ -209,6 +209,7 @@ require (
 	github.com/klauspost/compress v1.19.1 // indirect
 	github.com/kulti/thelper v0.7.1 // indirect
 	github.com/kunwardeep/paralleltest v1.0.15 // indirect
+	github.com/kylelemons/godebug v1.1.0 // indirect
 	github.com/lasiar/canonicalheader v1.1.2 // indirect
 	github.com/ldez/exptostd v0.4.5 // indirect
 	github.com/ldez/gomoddirectives v0.8.0 // indirect

--- a/integrationtests/scores_test.go
+++ b/integrationtests/scores_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	_ "github.com/jackc/pgx/v5/stdlib"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestScores(t *testing.T) {
@@ -100,6 +101,25 @@ func TestScores(t *testing.T) {
 			requestHeaders:     map[string]string{"Authorization": "Bearer sub-1"},
 			setup: func(db *sql.DB) {
 				executeSQLFile(t, db, "./test_data/games_setup_assigned.sql")
+			},
+		},
+		"Reject score for player not seated at the table (IDOR)": {
+			method:             "PUT",
+			endpoint:           "/games/1/rounds/1/tables/1/scores",
+			expectedStatusCode: http.StatusBadRequest,
+			// Player 17 exists but is seated at table 2, not table 1 (players 1, 5, 9, 13).
+			requestBody:    `{"scores": [{"playerID":1,"score":6},{"playerID":5,"score":3},{"playerID":9,"score":2},{"playerID":17,"score":1}]}`,
+			requestHeaders: map[string]string{"Authorization": "Bearer sub-1"},
+			setup: func(db *sql.DB) {
+				executeSQLFile(t, db, "./test_data/games_setup_assigned.sql")
+			},
+			assertions: func(t *testing.T, db *sql.DB) {
+				t.Helper()
+				var count int
+				if err := db.QueryRowContext(t.Context(), "SELECT count(*) FROM scores WHERE player_id = 17").Scan(&count); err != nil {
+					t.Fatalf("failed to query scores: %v", err)
+				}
+				assert.Equal(t, 0, count, "no score row may be written for a player not seated at the table")
 			},
 		},
 		"Update score invalid request body": {

--- a/pkg/table/service.go
+++ b/pkg/table/service.go
@@ -26,6 +26,11 @@ func (t *TablesService) UpdateScore(ctx context.Context, gameID, roundNumber, ta
 		return entity.GameTable{}, apperror.ErrInvalidScore
 	}
 
+	seatedPlayers := make(map[int]bool, len(table.Players))
+	for _, player := range table.Players {
+		seatedPlayers[player.ID] = true
+	}
+
 	existingScores := make(map[int]*entity.Score)
 	for _, score := range table.Scores {
 		existingScores[score.PlayerID] = score
@@ -33,6 +38,10 @@ func (t *TablesService) UpdateScore(ctx context.Context, gameID, roundNumber, ta
 
 	scores := make([]*entity.Score, 0, len(table.Players))
 	for _, s := range scoresRequest.Scores {
+		if !seatedPlayers[s.PlayerID] {
+			return entity.GameTable{}, apperror.ErrInvalidScore
+		}
+
 		if existingScore, exists := existingScores[s.PlayerID]; exists {
 			existingScore.Score = s.Score
 			scores = append(scores, existingScore)


### PR DESCRIPTION
## Summary

Two security issues found while auditing the authenticated API surface, both fixed here with regression tests.

### 1. 🟠 Cross-tenant score injection (IDOR) — `pkg/table/service.go`
`UpdateScore` validated only that the **count** of submitted scores matched the table's player count. Each score's `PlayerID` was never checked against the players actually seated at the table.

**Impact:** an authenticated owner of *any* game could `PUT .../scores` with `PlayerID`s belonging to **other users' players**. The FK `scores.player_id → players(id)` is satisfied by any existing player, and `UNIQUE(player_id, table_id)` doesn't collide because `table_id` is the attacker's own table — so the phantom rows are written additively, polluting victims' player score lists (and their game-completion state).

**Fix:** build the set of seated player IDs and reject any submitted `PlayerID` not in it (`ErrInvalidScore` → 400).

### 2. 🔴 Unbounded metric cardinality (DoS) — `api/middleware/metrics.go`
The Prometheus `handler` label used the raw `r.URL.Path`, which embeds unbounded resource IDs (`/games/{id}/rounds/{id}/...`). The `Metrics` middleware runs **before** `Authentication`, so an **unauthenticated** caller could spray distinct paths and create unbounded in-process time series → memory exhaustion / OOM of the API process.

**Fix:** label on the matched route template (`r.Pattern`, e.g. `GET /games/{gameID}`) instead of the concrete path. Go 1.26 sets `r.Pattern` before the per-route middleware runs.

## Tests
- `integrationtests/scores_test.go`: submitting a score for a player seated at a **different** table is rejected (400) and **no** `Score` row is written. Verified to fail against the pre-fix code (returned 200 + wrote the phantom row).
- `api/middleware/metrics_test.go`: three distinct concrete paths collapse into a single series keyed by the route template; the raw path never becomes a label value.

## Verification
- `go test ./...` — all pass (incl. testcontainers integration suite)
- `make lint` — 0 issues
- pre-commit (govulncheck, golangci-lint-full) — passed

## Not addressed here (from the same audit, lower severity / infra)
- Public pgweb (`db.knobel-manager.de`) behind only basic auth — highest real-world risk, infra-side.
- CORS `AllowedOrigins: ["*"]` + `AllowCredentials: true` (low impact given Bearer-token auth).
- No rate limiting; add-owner email user-enumeration oracle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)